### PR TITLE
Ubuntu 11.04 has codename 'natty'

### DIFF
--- a/templates/ubuntu-11.04/oracle-virtualbox.list.erb
+++ b/templates/ubuntu-11.04/oracle-virtualbox.list.erb
@@ -1,1 +1,1 @@
-deb http://download.virtualbox.org/virtualbox/debian maverick contrib non-free
+deb http://download.virtualbox.org/virtualbox/debian natty contrib non-free


### PR DESCRIPTION
Hello,

Please accept a small fix for the Ubuntu 11.04 template of the oracle sources.list entry. Ubuntu 11.04 has codename 'natty' instead of 'maverick'.

Please merge and release a new version of the cookbook on the Opscode Community Cookbooks site.

Greetz,

Ringo
