### PR TITLE
ubuntu/debian nonfree correction

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,27 +46,23 @@ when "mac_os_x"
 
 when "ubuntu","debian"
 
-  if not node['virtualbox']['open_source_edition']
+  bash "apt-get update" do
+    code "apt-get update"
+    action :nothing
+  end
 
-    bash "apt-get update" do
-      code "apt-get update"
-      action :nothing
-    end
+  bash "add Oracle key" do
+    code "wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc -O- | sudo apt-key add -"
+    action :nothing
+    notifies :run, resources(:bash => "apt-get update"), :immediately
+  end
 
-    bash "add Oracle key" do
-      code "wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc -O- | sudo apt-key add -"
-      action :nothing
-      notifies :run, resources(:bash => "apt-get update"), :immediately
-    end
-
-    template "/etc/apt/sources.list.d/oracle-virtualbox.list" do
-      source "oracle-virtualbox.list.erb"
-      mode 0644
-      notifies :run, resources(:bash => "add Oracle key"), :immediately
-    end
+  template "/etc/apt/sources.list.d/oracle-virtualbox.list" do
+    source "oracle-virtualbox.list.erb"
+    mode 0644
+    notifies :run, resources(:bash => "add Oracle key"), :immediately
   end
 
   package "virtualbox-#{node['virtualbox']['version']}"
-
+  package "dkms"
 end
-


### PR DESCRIPTION
The non open source extension pack is in a separate virtualbox extension file for all operating systems, so I pulled the opensource=false check out for debian/ubuntu. Unfortunately it looks like there is a random number in the downloads for the extension files that varies per virtual box version, so I punted on adding that for now.
