### PR TITLE
Added dmg cookbook as a dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,5 @@ license          "Apache 2.0"
 description      "Installs virtualbox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.6.2"
+
+depends          "dmg"


### PR DESCRIPTION
Hi Christopher,

only a small addition:
I've added the dmg cookbook as a dependency to metadata.rb. I know that this only applies to Mac OS X, but since we don't have platform-specific dependencies in metadata.rb yet, this seems to be the cleanest solution.

Thanks for your work!
Mike
