### PR TITLE
initial test kitchen 1.0 alpha support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver_plugin: vagrant
+
+platforms:
+- name: debian-6
+  driver_config:
+    box: opscode-debian-6.0.7
+    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_debian-6.0.7_chef-11.2.0.box
+    require_chef_omnibus: 11.4.0
+- name: ubuntu-12.04
+  driver_config:
+    box: canonical-ubuntu-12.04
+    box_url: http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box
+    require_chef_omnibus: true
+- name: centos-6.3
+  driver_config:
+    box: opscode-centos-6.3
+    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box
+
+suites:
+- name: default
+  run_list: ["recipe[virtualbox]"]
+  attributes: {}

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,2 @@
+site :opscode
+metadata

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,28 @@
+This cookbook includes support for running tests via Test Kitchen (1.0). This has some requirements.
+
+1. You must be using the Git repository, rather than the downloaded cookbook from the Chef Community Site.
+3. You must have Vagrant 1.1 installed, and no other previous versions of Vagrant hanging around.
+3. You must have a "sane" Ruby 1.9.3 environment.
+
+Once the above requirements are met, install the additional requirements:
+
+Install the berkshelf plugin for vagrant, use version 1.0.6.
+
+    vagrant plugin install berkshelf-vagrant --plugin-version 1.0.6
+
+Install berkshelf to your local Ruby environment.
+
+    gem install berkshelf
+
+Install Test Kitchen 1.0 (unreleased yet, use the alpha / prerelease version).
+
+    gem install test-kitchen --pre
+
+Install the Vagrant driver for Test Kitchen.
+
+    gem install kitchen-vagrant
+
+Once the above are installed, you should be able to run Test Kitchen:
+
+    kitchen list
+    kitchen test


### PR DESCRIPTION
See TESTING.md for instructions on setting up the local system to run the tests.

Doesn't support Windows / OS X (Yet?)
