### PR TITLE
Update cookbook version # and add appropriate dependency on yum cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,5 +13,5 @@ end
 depends "dmg"
 depends "windows"
 depends "apt"
-depends "yum", '~> 3.1.4'
+depends "yum", '>= 3.1.0'
 depends "apache2"


### PR DESCRIPTION
So, now that we have a version of the cookbook here on github that is compatible with the 3.x versions of the yum cookbook, it would be great if we could bump the version number of this cookbook and then get this pushed out to the community site.

The version that's on the community site now claims to be 1.0.2, but it's an older 1.0.2 that is not compatible with yum 3.x, and so this can cause some confusion.

Thanks!
