### PR TITLE
Compilation errors in virtualbox-cookbook recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,6 @@ when 'mac_os_x'
   default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/4.2.12/VirtualBox-4.2.12-84980-OSX.dmg'
 when 'windows'
   default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/4.2.12/VirtualBox-4.2.12-84980-Win.exe'
-  default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
   default['virtualbox']['version'] = '4.3'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ when 'mac_os_x'
 
 when 'windows'
 
+  node.default['virtualbox']['version'] = vbox_version(node['virtualbox']['url'])
   sha256sum = vbox_sha256sum(node['virtualbox']['url'])
   win_pkg_version = node['virtualbox']['version']
   Chef::Log.debug("Inspecting windows package version: #{win_pkg_version.inspect}")


### PR DESCRIPTION
 1) Typically it is not possible to use library functions in chef attribute  files. Hence using VBox::Helper  
     routine in attributes/default.rb caused compilation errors in a chef-solo run in a windows 8 box.
    (See Image below)
2) This commit moves the version detection logic from attributes/default.rb  to recipes/default.rb. And this  
     seems to work on Chef 11 via the command  'chef-solo --config solo.rb -j node.json'

![compilation error](https://cloud.githubusercontent.com/assets/6889702/2716509/192f2bce-c52c-11e3-9b73-255dc7a73e0d.png)
