### PR TITLE
build-essentials is required for building the kernel module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # changelog
 
+## v1.0.4
+* Add `build-essential` cookbook dependency
+
 ## 1.0.3
 * update `yum` dependency to 3

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Installs Virtualbox on OS X, Debian/Ubuntu or Windows.
 Changes
 =======
 
+## v1.0.4
+
+* Add `build-essential` cookbook dependency
+
 ## v1.0.3
 
 * Update `yum` dependency to version 3

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "bradleydsmith@gmail.com"
 license          "Apache 2.0"
 description      "Installs virtualbox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.3"
+version          "1.0.4"
 
 %w{ubuntu debian centos redhat mac_os_x windows fedora}.each do |os|
   supports os
@@ -15,3 +15,4 @@ depends "windows"
 depends "apt"
 depends "yum", '~> 3.1'
 depends "apache2"
+depends "build-essential"


### PR DESCRIPTION
It looks like build-essential should be required to build the kernel modules (at least in centos).
