### PR TITLE
install lsb and lsb-release on debian

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,6 +44,9 @@ when 'windows'
 
 when 'debian'
 
+  package 'lsb'
+  package 'lsb-release'
+  
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'
     key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,12 @@ when 'debian'
   package 'lsb'
   package 'lsb-release'
   
+  ohai "reload" do
+    action :reload
+    plugin "lsb"
+  end
+
+  
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'
     key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,13 +45,15 @@ when 'windows'
 when 'debian'
 
   package 'lsb'
-  package 'lsb-release'
-  
-  ohai "reload" do
-    action :reload
+
+  ohai "reload-lsb" do
+    action :nothing
     plugin "lsb"
   end
 
+  package 'lsb-release' do
+    notifies :reload, 'ohai[reload-lsb]', :immediately
+  end
   
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'


### PR DESCRIPTION
On debian node['lsb']['codename'] is empty unless the packages lsb and lsb-release are installed.
