### PR TITLE
Adding chefignore file

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,9 @@
+*/*file
+*/*file.lock
+bin/*
+bundle/*
+*/chefignore
+spec/*
+test/*
+vendor/*
+*/.git/*


### PR DESCRIPTION
When uploading this cookbook to chef-server (chef-guard, a tool we use to keep our server clean) companied about a missing directory `.git`.
I've downloaded the cookbook from the chef supermarket (https://supermarket.chef.io/api/v1/cookbooks/virtualbox/versions/1.0.3/download) and the `.git` directory is indeed there.

I think that including the `.git` directory and other files that are not necessary to a successful chef-client run is not desirable, hence the PR.