### PR TITLE
Set Key server using an attribute to resolve installation failure on …

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,5 +28,12 @@ when 'windows'
   default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/4.2.12/VirtualBox-4.2.12-84980-Win.exe'
   default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
-  default['virtualbox']['version'] = '4.3'
+  if node['platform'] == 'debian' && Chef::VersionConstraint.new('>= 8.0').include?(node['platform_version']) ||
+     node['platform'] == 'ubuntu' && Chef::VersionConstraint.new('>= 16.04').include?(node['platform_version'])
+    default['virtualbox']['version'] = '5.1'
+    default['virtualbox']['apt']['key'] = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
+  else
+    default['virtualbox']['version'] = '4.3'
+    default['virtualbox']['apt']['key'] = 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ when 'debian'
 
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'
-    key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
+    key node['virtualbox']['apt']['key']
     distribution node['lsb']['codename']
     components ['contrib']
   end
@@ -57,7 +57,7 @@ when 'debian'
 when 'rhel', 'fedora'
 
   yum_repository 'oracle-virtualbox' do
-    description "#{node['platform_family']} $releasever - $basearch - Virtualbox" 
+    description "#{node['platform_family']} $releasever - $basearch - Virtualbox"
     baseurl "http://download.virtualbox.org/virtualbox/rpm/#{node['platform_family']}/$releasever/$basearch"
     gpgcheck true
     gpgkey 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -5,7 +5,7 @@ describe 'virtualbox::default' do
     let(:chef_run) do
       ChefSpec::Runner.new(platform: 'centos', version: 6.4, step_into: ['yum_repository']) do |node|
         node.automatic['kernel']['machine'] = 'x86_64'
-        node.default['virtualbox']['version'] = 4.3 
+        node.default['virtualbox']['version'] = 4.3
       end.converge(described_recipe)
     end
 
@@ -14,5 +14,26 @@ describe 'virtualbox::default' do
       expect(chef_run).to create_yum_repository('oracle-virtualbox').with(url: 'http://download.virtualbox.org/virtualbox/rpm/rhel/$releasever/$basearch')
     end
 
+  end
+
+  context 'on Ubuntu 16.04 with virtualbox 5.1' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(platform: 'ubuntu', version: 16.04).converge(described_recipe)
+    end
+
+    it 'adds virtual box repository' do
+      expect(chef_run).to add_apt_repository('oracle-virtualbox').with(
+        uri: 'http://download.virtualbox.org/virtualbox/debian',
+        key: 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
+      )
+    end
+
+    it 'installs virtualbox package' do
+      expect(chef_run).to install_package('virtualbox-5.1')
+    end
+
+    it 'installs dkms package' do
+      expect(chef_run).to install_package('dkms')
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.formatter = :documentation
-  config.color_enabled = true
+  config.color = true
 end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
Installation on Ubuntu 16.04 fails with error shown below.  The apt key has been updated for Ubuntu 16.04 and Debian 8 (see https://www.virtualbox.org/wiki/Linux_Downloads).  I updated the default recipe to use an attribute for the apt_repository key.  In the default attributes file I've set the key to the appropriate value if the platform_version is Ubuntu 16.04 but I could have just left this as an attribute for anyone to override (I wasn't sure of the best approach as I'm not an expert on Chef).

I updated the chef spec test for the default recipe.  I also had to amend spec/spec_helper.rb to avoid a NoMethodError on color_enabled.  I assume this is because I'm using a newer version of chefspec (I'm using chefdk 0.16.28), hope that's OK. 

> ==> default:   \* apt_package[virtualbox-5.1] action install
> ==> default:  
> ==> default:     ================================================================================
> ==> default:     Error executing action `install` on resource 'apt_package[virtualbox-5.1]'
> ==> default:     ================================================================================
> ==> default:  
> ==> default:     Mixlib::ShellOut::ShellCommandFailed
> ==> default:     ------------------------------------
> ==> default:     Expected process to exit with [0], but received '100'
> ==> default:     ---- Begin output of apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial ----
> ==> default:     STDOUT: Reading package lists...
> ==> default:     Building dependency tree...
> ==> default:     Reading state information...
> ==> default:     The following additional packages will be installed:
> ==> default:       libqt5x11extras5 libsdl-ttf2.0-0 libsdl1.2debian
> ==> default:     The following NEW packages will be installed:
> ==> default:       libqt5x11extras5 libsdl-ttf2.0-0 libsdl1.2debian virtualbox-5.1
> ==> default:     0 upgraded, 4 newly installed, 0 to remove and 99 not upgraded.
> ==> default:     Need to get 65.1 MB of archives.
> ==> default:     After this operation, 158 MB of additional disk space will be used.
> ==> default:     WARNING: The following packages cannot be authenticated!
> ==> default:       virtualbox-5.1
> ==> default:     STDERR: E: There were unauthenticated packages and -y was used without --allow-unauthenticated
> ==> default:     ---- End output of apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial ----
> ==> default:     Ran apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial returned 100
> ==> default:  
> ==> default:     Cookbook Trace:
> ==> default:     ---------------
> ==> default:     /var/chef/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
> ==> default:     
> ==> default:     Resource Declaration:
> ==> default:     ---------------------
> ==> default:     # In /var/chef/cache/cookbooks/virtualbox/recipes/default.rb
> ==> default:     
> ==> default:      54:   package "virtualbox-#{node['virtualbox']['version']}"
> ==> default:      55:   package 'dkms'
> ==> default:     
> ==> default:     Compiled Resource:
> ==> default:     ------------------
> ==> default:     # Declared in /var/chef/cache/cookbooks/virtualbox/recipes/default.rb:54:in`from_file'
> ==> default:  
> ==> default:     apt_package("virtualbox-5.1") do
> ==> default:       package_name "virtualbox-5.1"
> ==> default:       action [:install]
> ==> default:       retries 0
> ==> default:       retry_delay 2
> ==> default:       default_guard_interpreter :default
> ==> default:       declared_type :package
> ==> default:       cookbook_name "virtualbox"
> ==> default:       recipe_name "default"
> ==> default:     end
> ==> default:  
> ==> default:     Platform:
> ==> default:     ---------
> ==> default:     x86_64-linux
> ==> default:  
> ==> default: 
> ==> default: Running handlers:
> ==> default: [2016-08-22T09:35:42+00:00] ERROR: Running exception handlers
> ==> default: Running handlers complete
> ==> default: [2016-08-22T09:35:42+00:00] ERROR: Exception handlers complete
> ==> default: Chef Client failed. 8 resources updated in 26 seconds
> ==> default: [2016-08-22T09:35:42+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
> ==> default: [2016-08-22T09:35:42+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
> ==> default: [2016-08-22T09:35:42+00:00] ERROR: apt_package[virtualbox-5.1](virtualbox::default line 54) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
> ==> default: ---- Begin output of apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial ----
> ==> default: STDOUT: Reading package lists...
> ==> default: Building dependency tree...
> ==> default: Reading state information...
> ==> default: The following additional packages will be installed:
> ==> default:   libqt5x11extras5 libsdl-ttf2.0-0 libsdl1.2debian
> ==> default: The following NEW packages will be installed:
> ==> default:   libqt5x11extras5 libsdl-ttf2.0-0 libsdl1.2debian virtualbox-5.1
> ==> default: 0 upgraded, 4 newly installed, 0 to remove and 99 not upgraded.
> ==> default: Need to get 65.1 MB of archives.
> ==> default: After this operation, 158 MB of additional disk space will be used.
> ==> default: WARNING: The following packages cannot be authenticated!
> ==> default:   virtualbox-5.1
> ==> default: STDERR: E: There were unauthenticated packages and -y was used without --allow-unauthenticated
> ==> default: ---- End output of apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial ----
> ==> default: Ran apt-get -q -y install virtualbox-5.1=5.1.4-110228~Ubuntu~xenial returned 100
> ==> default: [2016-08-22T09:35:44+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
