### PR TITLE
51update

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,12 @@ driver:
 verifier:
   name: inspec
 
+transport:
+  username: vagrant
+  password: vagrant
+  elevated: true
+  name: winrm
+
 provisioner:
   name: chef_zero
 
@@ -14,6 +20,10 @@ platforms:
   - name: debian-8.6
   - name: centos-6.8
   - name: centos-7.2
+  - name: windows-2016
+    driver:
+      box: mwrock/Windows2016
+      gui: false
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,23 +1,21 @@
----
-driver_plugin: vagrant
+
+driver:
+  name: vagrant
+
+verifier:
+  name: inspec
+
+provisioner:
+  name: chef_zero
 
 platforms:
-- name: debian-6
-  driver_config:
-    box: opscode-debian-6.0.7
-    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_debian-6.0.7_chef-11.2.0.box
-    require_chef_omnibus: 11.4.0
-- name: ubuntu-12.04
-  driver_config:
-    box: canonical-ubuntu-12.04
-    box_url: http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box
-    require_chef_omnibus: true
-- name: centos-6.3
-  driver_config:
-    box: opscode-centos-6.3
-    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box
+  - name: ubuntu-16.04
+  - name: debian-8.6
+  - name: centos-6.8
+  - name: centos-7.2
 
 suites:
 - name: default
-  run_list: ["recipe[virtualbox]"]
-  attributes: {}
+  run_list:
+    - recipe[virtualbox]
+  attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-16.04
+  - name: ubuntu-16.10
   - name: debian-8.6
   - name: centos-6.8
   - name: centos-7.2

--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
+
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # changelog
 
+## 2.0.1
+
+* update to VirtualBox 5.1 and confirm it works for following in test kitchen
+ * ubuntu-16.04, 16.10
+ * centos 6.8, 7.2
+ * debian 8.6
+* convert to inspec tests to verify successfull install in above environments
+
 ## 1.0.3
 * update `yum` dependency to 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # changelog
 
+## 2.0.3
+
+* VirtualBox 5.1.18 as default
+* Working test kitchen for Windows 2016 using publicly available Windows 2016
+image from @mwrock's [mrock/packer-templates](https://github.com/mwrock/packer-templates). Others should be able to converge & verify for windows systems.
+* Updating contact info in metadata 
+
 ## 2.0.1
 
 * update to VirtualBox 5.1 and confirm it works for following in test kitchen
  * ubuntu-16.04, 16.10
  * centos 6.8, 7.2
  * debian 8.6
-* convert to inspec tests to verify successfull install in above environments
+* convert to inspec tests to verify successful install in above environments
 
 ## 1.0.3
 * update `yum` dependency to 3

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Installs Virtualbox on OS X, Debian/Ubuntu or Windows.
 Changes
 =======
 
-## v2.0
+## v2.0.1
 
-* Update to Virtualbox 5.1 as default
-* Point to new VirtualBox Ubuntu 2016 signing key
+* Update to Virtualbox-5.1 as default
+* Point to new signing keys for Ubuntu and RHEL
+* Expand test kitchen to test on Debian, Ubuntu, and centos-6
+* Add inspec test to verify install of VirtualBox-5.1
 
 ## v1.0.4
 * Add chefignore
@@ -208,7 +210,7 @@ Contributions
 =============
 
 The source for this cookbook is hosted on
-[GitHub](https://github.com/peplin/virtualbox-cookbook). If you have any issues
+[GitHub](https://github.com/bradleyd/virtualbox-cookbook). If you have any issues
 with this cookbook, please follow up there.
 
 License and Author

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Installs Virtualbox on OS X, Debian/Ubuntu or Windows.
 Changes
 =======
 
+## v2.0
+
+* Update to Virtualbox 5.1 as default
+* Point to new VirtualBox Ubuntu 2016 signing key
+
 ## v1.0.4
 * Add chefignore
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,10 +23,10 @@ default['virtualbox']['version'] = ''
 
 case node['platform_family']
 when 'mac_os_x'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/4.2.12/VirtualBox-4.2.12-84980-OSX.dmg'
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-OSX.dmg'
 when 'windows'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/4.2.12/VirtualBox-4.2.12-84980-Win.exe'
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-Win.exe'
   default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
-  default['virtualbox']['version'] = '4.3'
+  default['virtualbox']['version'] = '5.1'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,10 +23,11 @@ default['virtualbox']['version'] = ''
 
 case node['platform_family']
 when 'mac_os_x'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-OSX.dmg'
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.18/VirtualBox-5.1.18-114002-OSX.dmg'
 when 'windows'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-Win.exe'
-  default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.18/VirtualBox-5.1.18-114002-Win.exe'
+  default['virtualbox']['version'] = '5.1.18'
+#  Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
   default['virtualbox']['version'] = '5.1'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,9 +23,9 @@ default['virtualbox']['version'] = ''
 
 case node['platform_family']
 when 'mac_os_x'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-OSX.dmg'
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-OSX.dmg'
 when 'windows'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-Win.exe'
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-Win.exe'
   default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
   default['virtualbox']['version'] = '5.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,8 +24,10 @@ default['virtualbox']['version'] = ''
 case node['platform_family']
 when 'mac_os_x'
   default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-OSX.dmg'
+  # http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-OSX.dmg
 when 'windows'
   default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-Win.exe'
+  # http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-Win.exe
   default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
   default['virtualbox']['version'] = '5.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,11 +23,9 @@ default['virtualbox']['version'] = ''
 
 case node['platform_family']
 when 'mac_os_x'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-OSX.dmg'
-  # http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-OSX.dmg
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-OSX.dmg'
 when 'windows'
-  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.14/VirtualBox-5.1.14-112924-Win.exe'
-  # http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-Win.exe
+  default['virtualbox']['url'] = 'http://download.virtualbox.org/virtualbox/5.1.16/VirtualBox-5.1.16-113841-Win.exe'
   default['virtualbox']['version'] = Vbox::Helpers.vbox_version(node['virtualbox']['url'])
 when 'debian', 'rhel', 'fedora'
   default['virtualbox']['version'] = '5.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "bradleydsmith@gmail.com"
 license          "Apache 2.0"
 description      "Installs virtualbox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.4"
+version          "2.0.1"
 
 %w{ubuntu debian centos redhat mac_os_x windows fedora}.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email "broderson@gmail.com"
 license          "Apache 2.0"
 description      "Installs virtualbox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.2"
+version          "2.0.3"
 
 source_url "https://github.com/dayne/virtualbox-cookbook"
 issues_url "https://github.com/dayne/virtualbox-cookbook/issues"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,15 @@
 name             "virtualbox"
-maintainer       "Bradley D Smith"
-maintainer_email "bradleydsmith@gmail.com"
+# maintainer       "Bradley D Smith"
+# maintainer_email "bradleydsmith@gmail.com"
+maintainer       "Dayne Broderson"
+maintainer_email "broderson@gmail.com"
 license          "Apache 2.0"
 description      "Installs virtualbox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.1"
+version          "2.0.2"
+
+source_url "https://github.com/dayne/virtualbox-cookbook"
+issues_url "https://github.com/dayne/virtualbox-cookbook/issues"
 
 %w{ubuntu debian centos redhat mac_os_x windows fedora}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,6 @@ when 'debian'
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'
     key 'A2F683C52980AECF'
-    #key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc'
     distribution node['lsb']['codename']
     components ['contrib']
   end
@@ -61,7 +60,7 @@ when 'rhel', 'fedora'
     description "#{node['platform_family']} $releasever - $basearch - Virtualbox"
     baseurl "http://download.virtualbox.org/virtualbox/rpm/#{node['platform_family']}/$releasever/$basearch"
     gpgcheck true
-    gpgkey 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc'
+    gpgkey 'https://www.virtualbox.org/download/oracle_vbox.asc'
   end
 
   package "VirtualBox-#{node['virtualbox']['version']}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,8 @@ when 'debian'
 
   apt_repository 'oracle-virtualbox' do
     uri 'http://download.virtualbox.org/virtualbox/debian'
-    key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
+    key 'A2F683C52980AECF'
+    #key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc'
     distribution node['lsb']['codename']
     components ['contrib']
   end
@@ -57,10 +58,10 @@ when 'debian'
 when 'rhel', 'fedora'
 
   yum_repository 'oracle-virtualbox' do
-    description "#{node['platform_family']} $releasever - $basearch - Virtualbox" 
+    description "#{node['platform_family']} $releasever - $basearch - Virtualbox"
     baseurl "http://download.virtualbox.org/virtualbox/rpm/#{node['platform_family']}/$releasever/$basearch"
     gpgcheck true
-    gpgkey 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
+    gpgkey 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc'
   end
 
   package "VirtualBox-#{node['virtualbox']['version']}"

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe 'virtualbox::default' do
-  context 'on Centos 6.4 x86_64 with virtualbox 4.3' do
+  context 'on Centos 6.8 x86_64 with virtualbox 5.1' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: 6.4, step_into: ['yum_repository']) do |node|
+      ChefSpec::Runner.new(platform: 'centos', version: 6.8, step_into: ['yum_repository']) do |node|
         node.automatic['kernel']['machine'] = 'x86_64'
-        node.default['virtualbox']['version'] = 4.3 
+        node.default['virtualbox']['version'] = 5.1
       end.converge(described_recipe)
     end
 

--- a/test/integration/default/bats/installed.bats
+++ b/test/integration/default/bats/installed.bats
@@ -1,6 +1,0 @@
-#!/usr/bin/env bats
-
-@test 'virtualbox-4.3 is installed' {
-  run test "rpm -qa Virtualbox-4.3 || dpkg-query -s virtualbox-4.3"
-  [ "$status" -eq 0 ]
-}

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,9 @@
+describe package('VirtualBox-5.1') do
+  it { should be_installed }
+end
+
+describe command('virtualbox --help') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match 'Oracle VM VirtualBox Manager' }
+  its('stderr') { should match '' }
+end


### PR DESCRIPTION
Thanks for your Virtualbox Cookbook.  

This pull request updates the cookbook to install the latest VirtualBox (5.1.14) and updates test kitchen systems. 

Updated the test kitchen do ubuntu 16.04, debian 8.6, centos 6.8 and centos 7.2.  All of these converge successfully.  

Converted to inspec tests to verify install of 5.1 happened. 

With the attached updates I've found it to be working great for my Ubuntu 16.10 system.

Did not try to review how well (or not) this works for Windows or OSX.

Let me know if you'd like any more details or tweaks.